### PR TITLE
Java 9 module support and github actions CI

### DIFF
--- a/.github/workflows/JavaCI.yaml
+++ b/.github/workflows/JavaCI.yaml
@@ -1,0 +1,28 @@
+name: Java CI
+on: [push]
+jobs:
+  build-and-test:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        java: [ '9', '11' ]
+    name: Test on Java ${{matrix.java}}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup JDK ${{matrix.java}}
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: ${{matrix.java}}
+      - name: Build jar with Gradle
+        run: ./gradlew jar
+      - name: Run tests with Gradle
+        run: ./gradlew test jococoTestReport
+      - uses: actions/upload-artifact@v2
+        with:
+          name: Jar
+          path: build/libs
+      - uses: actions/upload-artifact@v2
+        with:
+          name: Reports
+          path: build/reports

--- a/.github/workflows/JavaCI.yaml
+++ b/.github/workflows/JavaCI.yaml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        java: [ '9', '11' ]
+        java: [ '11' ]
     name: Test on Java ${{matrix.java}}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/JavaCI.yaml
+++ b/.github/workflows/JavaCI.yaml
@@ -17,12 +17,14 @@ jobs:
       - name: Build jar with Gradle
         run: ./gradlew jar
       - name: Run tests with Gradle
-        run: ./gradlew test jococoTestReport
-      - uses: actions/upload-artifact@v2
+        run: ./gradlew test jacocoTestReport
+      - name: Upload Jar
+        uses: actions/upload-artifact@v2
         with:
           name: Jar
           path: build/libs
-      - uses: actions/upload-artifact@v2
+      - name: Upload Reports
+        uses: actions/upload-artifact@v2
         with:
           name: Reports
           path: build/reports

--- a/.github/workflows/JavaCI.yaml
+++ b/.github/workflows/JavaCI.yaml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup JDK ${{matrix.java}}
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: ${{matrix.java}}
       - name: Build jar with Gradle
         run: ./gradlew jar

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ A java keystore implementation to use PEM files directly, instead of converting 
 
 The keystore also implements scheduled/automatic reloading of certificates in case of change, so it can be used with short lived certificates, for example Let's Encrypt certificates, without application reset (or creating a new SSLContext / Socket).
  
+## Module support
+
+As of version 0.4, the keystore has been ported to module for better Java 9+ compatibility. Please use version 0.3 if you are using Java 8.
+
+The module name is `io.r2io.simplepemkeystore`. Unfortunately it can't match the package name, as module name can't contain trailing numbers :(
+
 ## Compile
 
 ```Shell
@@ -12,7 +18,7 @@ The keystore also implements scheduled/automatic reloading of certificates in ca
 
 ## Get
 
-The latest release version (0.3) is available in the Maven Central repository.
+The latest release version (0.4) is available in the Maven Central repository.
 
 For maven:
 
@@ -20,14 +26,14 @@ For maven:
 	<dependency>
 	    <groupId>io.r2</groupId>
 	    <artifactId>simple-pem-keystore</artifactId>
-	    <version>0.3</version>
+	    <version>0.4</version>
 	</dependency>
 ```
 
 For gradle:
 
 ```gradle
-	compile group: 'io.r2', name: 'simple-pem-keystore', version: '0.3'
+	compile group: 'io.r2', name: 'simple-pem-keystore', version: '0.4'
 ```
 
 ## Registering the security provider
@@ -189,6 +195,5 @@ Licensed under the MIT license.
  
 ## Requirements
 
-Java 8 is required to compile or run.
+Java 9 is required to compile or run.
 Also depends on jackson-databind.
-

--- a/build.gradle
+++ b/build.gradle
@@ -11,17 +11,17 @@ version = "0.4-SNAPSHOT"
 defaultTasks "jar"
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {
     implementation (
-        'com.fasterxml.jackson.core:jackson-databind:2.7.4'
+        'com.fasterxml.jackson.core:jackson-databind:2.12.5'
     )
     testImplementation (
-        'org.testng:testng:6.9.12',
-        'org.assertj:assertj-core:3.5.2',
-        'org.mockito:mockito-core:2.2.17'
+        'org.testng:testng:7.4.0',
+        'org.assertj:assertj-core:3.20.2',
+        'org.mockito:mockito-core:3.12.4'
     )
 }
 
@@ -33,13 +33,18 @@ javadoc {
     exclude "io/r2/simplepemkeystore/spi/**"
 }
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 1.9
+targetCompatibility = 1.9
 
 java {
     withJavadocJar()
     withSourcesJar()
 }
+
+compileJava {
+    options.deprecation = true;
+}
+
 
 publishing {
     publications {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
 # dummy properties for compiling, override in ${USER}/.gradle/gradle.properties
 ossrhUsername=
 ossrhPassword=
+systemProp.https.protocols=TLSv1,TLSv1.1,TLSv1.2,TLSv1.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,3 @@
 # dummy properties for compiling, override in ${USER}/.gradle/gradle.properties
 ossrhUsername=
 ossrhPassword=
-systemProp.https.protocols=TLSv1,TLSv1.1,TLSv1.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 # dummy properties for compiling, override in ${USER}/.gradle/gradle.properties
 ossrhUsername=
 ossrhPassword=
-systemProp.https.protocols=TLSv1,TLSv1.1,TLSv1.2,TLSv1.3
+systemProp.https.protocols=TLSv1,TLSv1.1,TLSv1.2

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/io/r2/simplepemkeystore/SimplePemKeyStoreProvider.java
+++ b/src/main/java/io/r2/simplepemkeystore/SimplePemKeyStoreProvider.java
@@ -11,8 +11,8 @@ public final class SimplePemKeyStoreProvider extends Provider {
     public SimplePemKeyStoreProvider() {
         super(
                 "SimplePemKeyStore",
-                0.3,
-                "SimplePemKeyStore 0.3 - PEM based key stores with automatic reloading"
+                "0.4",
+                "SimplePemKeyStore 0.4 - PEM based key stores with automatic reloading"
         );
         put("KeyStore.simplepem", "io.r2.simplepemkeystore.spi.SimplePemKeyStoreSpi");
         put("KeyStore.simplepemreload", "io.r2.simplepemkeystore.spi.ReloadablePemKeyStoreSpi");

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,5 @@
+module io.r2io.simplepemkeystore {
+    exports io.r2.simplepemkeystore;
+    requires java.base;
+    requires com.fasterxml.jackson.databind;
+}


### PR DESCRIPTION
Note: CI only tests on JDK 11 as JDK 9 was having strange https certificate chain  issues downloading dependencies from maven central.